### PR TITLE
Use heading text to generate IDs instead of random string

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+Closes {LINK TO GH ISSUE}
+
+
 ## Description
 <!--
 A clear and concise description of the PR.
@@ -9,8 +12,6 @@ Use this section for review hints, explanations or discussion points/todos.
 
 How to contribute: https://kelpui.com/docs/getting-started/contributing/
 -->
-
-Closes {LINK TO GH ISSUE}
 
 
 ## Docs

--- a/js/components/heading-anchors.js
+++ b/js/components/heading-anchors.js
@@ -1,6 +1,7 @@
 import { debug } from '../utilities/debug.js';
 import { emit } from '../utilities/emit.js';
 import { ready } from '../utilities/ready.js';
+import { setHeadingID } from '../utilities/setHeadingID.js';
 
 customElements.define('kelp-heading-anchors', class extends HTMLElement {
 
@@ -45,9 +46,7 @@ customElements.define('kelp-heading-anchors', class extends HTMLElement {
 			heading.classList.add('anchor-h');
 
 			// Add missing IDs
-			if (!heading.id) {
-				heading.id = `h_${crypto.randomUUID()}`;
-			}
+			setHeadingID(heading);
 
 			// Create anchor content
 			const text = `<span class="anchor-text">${heading.innerHTML}</span>`;

--- a/js/components/toc.js
+++ b/js/components/toc.js
@@ -1,6 +1,7 @@
 import { debug } from '../utilities/debug.js';
 import { emit } from '../utilities/emit.js';
 import { ready } from '../utilities/ready.js';
+import { setHeadingID } from '../utilities/setHeadingID.js';
 
 customElements.define('kelp-toc', class extends HTMLElement {
 
@@ -73,9 +74,7 @@ customElements.define('kelp-toc', class extends HTMLElement {
 			const heading = headings[this.index.val];
 
 			// If there's no heading, create one
-			if (!heading.id) {
-				heading.id = `h_${crypto.randomUUID()}`;
-			}
+			setHeadingID(heading);
 
 			// Get the current and next heading levels
 			const currentLevel = heading.tagName.slice(1);

--- a/js/utilities/setHeadingID.js
+++ b/js/utilities/setHeadingID.js
@@ -1,0 +1,8 @@
+/**
+ * Convert heading text into a valid ID and set it on the element
+ * @param  {Element} heading The heading element
+ */
+export function setHeadingID (heading) {
+	if (heading.id) return;
+	heading.id = `h_${heading.textContent.replace(/\W/g,'-')}`;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kelpui",
-	"version": "0.14.2",
+	"version": "0.14.3",
 	"description": "A UI library for people who love HTML, powered by modern CSS and Web Components.",
 	"keywords": [
 		"html",

--- a/tests/toc/default.html
+++ b/tests/toc/default.html
@@ -33,7 +33,7 @@
 			<h4>Privateer</h4>
 			<h2>Ahoy</h2>
 			<h3 id="man-of-war">Man-of-War</h3>
-			<h2 id="corsair">Corsair</h2>
+			<h2 data-testid="valid-id">123 #^&%@<code>.text-small</code> 是不 Sábado 😀🎉</h2>
 			<h3 id="shiver-me-timbers">Shiver Me Timbers</h3>
 			<h2 id="scurvy-dog">Scurvy Dog</h2>
 			<h4>Sea Legs</h4>

--- a/tests/toc/toc.spec.js
+++ b/tests/toc/toc.spec.js
@@ -18,6 +18,8 @@ test.describe(`<${componentName}>`, () => {
 		const numberOfLinks = await links.count();
 		const heading = page.locator('h2');
 		const headingID = await heading.first().evaluate((elem) => elem.id);
+		const validIDHeading = await page.getByTestId('valid-id');
+		const validID = await validIDHeading.first().evaluate((elem) => elem.id);
 
 		// Number of links should match number of H2 headings
 		await expect(numberOfLinks).toEqual(5);
@@ -26,6 +28,9 @@ test.describe(`<${componentName}>`, () => {
 		// and their values are used in the ToC
 		await expect(headingID).toBeTruthy();
 		await expect(links.first()).toHaveAttribute('href', `#${headingID}`);
+
+		// IDs are valid
+		await expect(validID).toEqual('h_123-------text-small----S-bado-----');
 
 	});
 


### PR DESCRIPTION
Closes https://github.com/cferdinandi/kelp/issues/168

## Description

Generates missing IDs from heading text instead of randomly. This means anchor text will be consistent from one page view to another, supporting deep-linking.