### PR TITLE
Adds missing .gap-s class

### DIFF
--- a/modules/css/utilities/gap.css
+++ b/modules/css/utilities/gap.css
@@ -33,6 +33,10 @@
 		--gap: var(--size-xs);
 	}
 
+	.gap-s {
+		--gap: var(--size-s);
+	}
+	
 	.gap-m {
 		--gap: var(--size-m);
 	}


### PR DESCRIPTION
## Description

Added `.gap-s` class to `size.css` file.

I just noticed that the `.gap-s` class was missing among the gaps while the custom property exists and the corresponding docs page claims that there is a `.gap-s` class.

btw, thanks for this lib! Will try it out soon in a project. Had something like this in mind for a little while ...

## Docs

No new docs

## Ready?

- [x] Documented what's new (already existed)
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Kelp Contributor License Agreement

I give Chris Ferdinandi and Go Make Things, LLC permission to license my contributions on any terms they like. I am giving them this license in order to make it possible for them to accept my contributions into their project.

**_As far as the law allows, my contributions come as is, without any warranty or condition, and I will not be liable to anyone for any damages related to this software or this license, under any kind of legal claim._**
