### PR TITLE
Scroll Shift

### DIFF
--- a/css/kelp.css
+++ b/css/kelp.css
@@ -1,4 +1,4 @@
-/*! kelpui v1.3.0 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
+/*! kelpui v1.3.1 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
 /* modules/css/layers/layers.css */
 @layer kelp;
 @layer kelp.base, kelp.theme, kelp.core, kelp.extend, kelp.utilities, kelp.helpers, kelp.tokens, kelp.state, kelp.effects;
@@ -374,7 +374,7 @@
   html {
     font-size: var(--font-size-base);
     scroll-behavior: smooth;
-    overflow-y: scroll;
+    scrollbar-gutter: stable;
     -moz-text-size-adjust: none;
     -webkit-text-size-adjust: none;
     text-size-adjust: none;

--- a/index.html
+++ b/index.html
@@ -1164,7 +1164,7 @@
 
 			</kelp-heading-anchors>
 
-			<dialog class="modal" id="modal" closedby="any">
+			<dialog id="modal" closedby="any">
 				<div class="action-header">
 					<h2>This is a modal heading</h2>
 					<form>

--- a/js/dark-mode-auto.js
+++ b/js/dark-mode-auto.js
@@ -1,4 +1,4 @@
-/*! kelpui v1.3.0 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
+/*! kelpui v1.3.1 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
 "use strict";
 (() => {
   // modules/js/dark-mode-auto.js

--- a/js/kelp.js
+++ b/js/kelp.js
@@ -1,4 +1,4 @@
-/*! kelpui v1.3.0 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
+/*! kelpui v1.3.1 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
 "use strict";
 (() => {
   // modules/js/utilities/debug.js
@@ -527,7 +527,7 @@
   });
 
   // modules/js/components/invoker.polyfill.js
-  //! Invoker Command API Polyfill by Keith Cirkel - https://github.com/keithamus/invokers-polyfill/tree/main
+  //! Invoker Command API Polyfill by Keith Cirkel - https://github.com/keithamus/invokers-polyfill/tree/main - MIT License
   function isSupported() {
     return typeof HTMLButtonElement !== "undefined" && "command" in HTMLButtonElement.prototype && "source" in ((globalThis.CommandEvent || {}).prototype || {});
   }

--- a/modules/css/native/base.css
+++ b/modules/css/native/base.css
@@ -15,14 +15,14 @@
 	}
 
 	/**
-	 * 1. Force scrollbar display to prevent jumping on pages.
+	 * 1. Hold space for scrollbar to prevent jumping on pages.
 	 * 2. Prevent iOS text size adjust after orientation change, without disabling
 	 *    user zoom.
 	 */
 	html {
 		font-size: var(--font-size-base);
 		scroll-behavior: smooth;
-		overflow-y: scroll; /* 1 */
+		scrollbar-gutter: stable; /* 1 */
 		/* 2 */
 		-moz-text-size-adjust: none;
 		-webkit-text-size-adjust: none;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kelpui",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kelpui",
-			"version": "1.3.0",
+			"version": "1.3.1",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"http-server": "^14.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kelpui",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "A UI library for people who love HTML, powered by modern CSS and Web Components.",
 	"keywords": [
 		"html",


### PR DESCRIPTION
Closes https://github.com/cferdinandi/kelp/issues/218


## Description
Replaces `overflow-y: scroll` on the HTML element with `scrollbar-gutter: stable`. This holds space for the scrollbar whether its displayed or not, so that setting `overflow: hidden` (such as when a modal is open) does not result in a horizontal shift.