### PR TITLE
Forced-Color Mode

### DIFF
--- a/css/kelp.css
+++ b/css/kelp.css
@@ -1,4 +1,4 @@
-/*! kelpui v1.5.1 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
+/*! kelpui v1.5.2 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
 /* modules/css/layers/layers.css */
 @layer kelp;
 @layer kelp.base, kelp.theme, kelp.core, kelp.extend, kelp.utilities, kelp.helpers, kelp.tokens, kelp.state, kelp.effects;
@@ -551,6 +551,12 @@
     background: var(--color-fill-highlight);
     color: var(--color-on-highlight);
   }
+  @media (forced-colors: active) {
+    mark {
+      background: revert;
+      color: revert;
+    }
+  }
   del {
     color: color-mix(in oklab, var(--color), var(--color-mix-deleted));
   }
@@ -601,6 +607,11 @@
   }
   .dark ::-webkit-calendar-picker-indicator {
     filter: invert(1);
+  }
+  @media (forced-colors: active) {
+    .dark ::-webkit-calendar-picker-indicator {
+      filter: invert(1);
+    }
   }
   input,
   textarea,
@@ -674,6 +685,11 @@
     content: "";
     width: 0.667em;
     aspect-ratio: 1;
+  }
+  @media (forced-colors: active) {
+    [type=radio]:checked::after {
+      content: "\2713";
+    }
   }
   [type=checkbox]:checked {
     background-color: var(--color-checked);
@@ -841,6 +857,11 @@
     max-width: calc(100% - var(--size-5xl));
     padding: var(--gap);
     width: var(--width);
+  }
+  @media (forced-colors: active) {
+    dialog {
+      border-width: var(--size-5xs);
+    }
   }
   dialog:modal::backdrop {
     background-color: rgba(0, 0, 0, 0.5);
@@ -1349,6 +1370,11 @@
     height: var(--height);
     width: var(--width);
   }
+  @media (forced-colors: active) {
+    .skeleton {
+      border: var(--size-6xs) solid;
+    }
+  }
   @keyframes loadingPulse {
     0% {
       background-color: var(--color-fill-accent);
@@ -1390,6 +1416,11 @@
   kelp-tabs [role=tab][aria-selected=true] {
     background-color: var(--tab-background-color-selected);
     color: var(--tab-color-selected);
+  }
+  @media (forced-colors: active) {
+    kelp-tabs [role=tab][aria-selected=true] {
+      border-width: var(--size-5xs);
+    }
   }
 }
 

--- a/js/dark-mode-auto.js
+++ b/js/dark-mode-auto.js
@@ -1,4 +1,4 @@
-/*! kelpui v1.5.1 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
+/*! kelpui v1.5.2 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
 "use strict";
 (() => {
   // modules/js/dark-mode-auto.js

--- a/js/kelp.js
+++ b/js/kelp.js
@@ -1,4 +1,4 @@
-/*! kelpui v1.5.1 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
+/*! kelpui v1.5.2 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
 "use strict";
 (() => {
   // modules/js/utilities/debug.js

--- a/modules/css/components/skeleton.css
+++ b/modules/css/components/skeleton.css
@@ -18,6 +18,12 @@
 		width: var(--width);
 	}
 
+	@media (forced-colors: active) {
+		.skeleton {
+			border: var(--size-6xs) solid;
+		}
+	}
+
 	@keyframes loadingPulse {
 		0% {
 			background-color: var(--color-fill-accent);

--- a/modules/css/components/tabs.css
+++ b/modules/css/components/tabs.css
@@ -39,4 +39,10 @@
 		color: var(--tab-color-selected);
 	}
 
+	@media (forced-colors: active) {
+		kelp-tabs [role="tab"][aria-selected="true"] {
+			border-width: var(--size-5xs);
+		}
+	}
+
 }

--- a/modules/css/native/accents.css
+++ b/modules/css/native/accents.css
@@ -17,6 +17,13 @@
 		color: var(--color-on-highlight);
 	}
 
+	@media (forced-colors: active) {
+		mark {
+			background: revert;
+			color: revert;
+		}
+	}
+
 	del {
 		color: color-mix(in oklab, var(--color), var(--color-mix-deleted));
 	}

--- a/modules/css/native/dialog.css
+++ b/modules/css/native/dialog.css
@@ -32,6 +32,12 @@
 		width: var(--width);
 	}
 
+	@media (forced-colors: active) {
+		dialog {
+			border-width: var(--size-5xs);
+		}
+	}
+
 	dialog:modal::backdrop {
 		background-color: rgba(0, 0, 0, 0.5);
 	}

--- a/modules/css/native/forms.css
+++ b/modules/css/native/forms.css
@@ -76,6 +76,12 @@
 		filter: invert(1);
 	}
 
+	@media (forced-colors: active) {
+		.dark ::-webkit-calendar-picker-indicator {
+			filter: invert(1);
+		}
+	}
+
 	input,
 	textarea,
 	select {
@@ -177,6 +183,12 @@
 		content: '';
 		width: 0.667em;
 		aspect-ratio: 1;
+	}
+
+	@media (forced-colors: active) {
+		[type="radio"]:checked::after {
+			content: '\002713';
+		}
 	}
 
 	[type="checkbox"]:checked {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kelpui",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kelpui",
-			"version": "1.5.1",
+			"version": "1.5.2",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"http-server": "^14.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kelpui",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "A UI library for people who love HTML, powered by modern CSS and Web Components.",
 	"keywords": [
 		"html",


### PR DESCRIPTION
Closes https://github.com/cferdinandi/kelp/issues/210


## Description
This PR adds support for forced-color mode:

- Borders to the skeleton component
- Thicker borders on active tabs
- More visible `<mark>` element color
- Thicker borders on `<dialog>` elements (better contrast against background)
- Added icon for radio button 
