### PR TITLE
Hide Until Selected component

### DIFF
--- a/css/kelp.css
+++ b/css/kelp.css
@@ -1,4 +1,4 @@
-/*! kelpui v1.16.0 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
+/*! kelpui v1.17.0 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
 /* src/css/config/layers.css */
 @layer kelp;
 @layer kelp.base, kelp.theme, kelp.core, kelp.extend, kelp.utilities, kelp.helpers, kelp.tokens, kelp.state, kelp.effects;

--- a/js/dark-mode-auto.js
+++ b/js/dark-mode-auto.js
@@ -1,4 +1,4 @@
-/*! kelpui v1.16.0 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
+/*! kelpui v1.17.0 | (c) Chris Ferdinandi | http://github.com/cferdinandi/kelp */
 "use strict";
 (() => {
   // src/js/dark-mode-auto.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kelpui",
-	"version": "1.16.0",
+	"version": "1.17.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kelpui",
-			"version": "1.16.0",
+			"version": "1.17.0",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"http-server": "^14.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kelpui",
-	"version": "1.16.0",
+	"version": "1.17.0",
 	"description": "A UI library for people who love HTML, powered by modern CSS and Web Components.",
 	"keywords": [
 		"html",

--- a/src/js/components/hide-until-selected.js
+++ b/src/js/components/hide-until-selected.js
@@ -1,0 +1,187 @@
+import { debug } from '../utilities/debug.js';
+import { emit } from '../utilities/emit.js';
+import { ready } from '../utilities/ready.js';
+
+customElements.define(
+	'kelp-hide-until-selected',
+	class extends HTMLElement {
+		/** @type String | null */ #target;
+		/** @type String */ #method;
+		/** @type String | null */ #focus;
+		/** @type String[] */ #events;
+		/** @type String[] */ #keys;
+
+		// Initialize on connect
+		connectedCallback() {
+			ready(this);
+		}
+
+		// Cleanup global events on disconnect
+		disconnectedCallback() {
+			document.removeEventListener('input', this);
+			document.removeEventListener('kelp-select-all:toggle', this);
+			for (const name of this.#events) {
+				document.removeEventListener(name, this);
+			}
+			this.#toggleVisibility(true);
+		}
+
+		// Initialize the component
+		init() {
+			// Define component options
+			this.#target = this.getAttribute('target');
+			this.#method = this.getAttribute('action') || 'hidden';
+			this.#focus = this.getAttribute('focus');
+
+			// Get events and keys to listen for (optional)
+			this.#events = (this.getAttribute('events')?.split(',') || [])
+				.map((name) => name.trim())
+				.filter((name) => name.trim());
+			this.#keys = (this.getAttribute('keys')?.split(',') || [])
+				.map((key) => key.trim())
+				.filter((key) => key.trim());
+
+			// Check for required attributes
+			if (!this.#target) {
+				debug(this, 'No target selector provided');
+				return;
+			}
+
+			if (!['invisible', 'disabled', 'hidden'].includes(this.#method)) {
+				debug(this, 'Invalid action specified');
+				return;
+			}
+
+			// Set initial visibility
+			this.#toggleVisibility();
+
+			// Listen for events
+			document.addEventListener('input', this);
+			document.addEventListener('kelp-select-all:toggle', this);
+
+			// Listen for custom events
+			for (const name of this.#events) {
+				document.addEventListener(name, this);
+			}
+
+			// Ready
+			emit(this, 'hide-until-selected', 'ready');
+			this.setAttribute('is-ready', '');
+		}
+
+		/**
+		 * Handle events
+		 * @param  {Event} event The event object
+		 */
+		handleEvent(event) {
+			if (event.type === 'input') {
+				return this.#onInput(event);
+			}
+			if (event.type === 'kelp-select-all:toggle') {
+				return this.#onSelectAllToggle(event);
+			}
+			this.#onCustomEvent(event);
+		}
+
+		/**
+		 * Handle custom events
+		 * @param  {Event | CustomEvent} event The event object
+		 */
+		#onCustomEvent(event) {
+			// Only run if the event is one of the target event names
+			if (!this.#events.includes(event.type)) return;
+
+			// Only run on custom events
+			if (!(event instanceof CustomEvent)) return;
+
+			// If there are event keys, make sure the event has a matching key
+			if (this.#keys.length) {
+				if (!event?.detail?.eventKeys || !Array.isArray(event.detail.eventKeys))
+					return;
+				const hasMatch = this.#keys.find((key) =>
+					event.detail.eventKeys.includes(key),
+				);
+				if (!hasMatch) return;
+			}
+
+			// If it's a matching event, toggle visibility
+			this.#toggleVisibility();
+		}
+
+		/**
+		 * Handle select toggle events
+		 * @param  {Event | CustomEvent} event The event object
+		 */
+		#onSelectAllToggle(event) {
+			if (!(event instanceof CustomEvent) || !this.#target) return;
+
+			// Only run if checkbox is a controlling checkbox
+			if (!event?.detail?.checkbox.matches(this.#target)) return;
+
+			// Toggle visibility
+			this.#toggleVisibility();
+		}
+
+		/**
+		 * Handle input events
+		 * @param  {Event} event The event object
+		 */
+		#onInput(event) {
+			if (!(event.target instanceof Element) || !this.#target) return;
+
+			// Only run if event.target is a controlling checkbox
+			if (!event.target.matches(this.#target)) return;
+
+			// Toggle visibility
+			this.#toggleVisibility();
+		}
+
+		/**
+		 * Check if any controlling checkbox is checked
+		 * @return {Boolean} If true, at least one checkbox is checked
+		 */
+		#isAnyCheckboxChecked() {
+			if (!this.#target) return false;
+			const checkboxes = [...document.querySelectorAll(this.#target)];
+			return !!checkboxes.find(
+				(checkbox) => checkbox instanceof HTMLInputElement && checkbox.checked,
+			);
+		}
+
+		/**
+		 * Toggle the visibility of content elements
+		 * @param  {Boolean} forceShow If true, display content regardless of checkbox state
+		 */
+		#toggleVisibility(forceShow = false) {
+			// Check if content should be shown or hidden
+			const shouldBeExpanded = forceShow || this.#isAnyCheckboxChecked();
+
+			// Manage focus
+			if (!shouldBeExpanded && this.#focus && this.matches(':focus-within')) {
+				/** @type {HTMLElement} */ (
+					document.querySelector(this.#focus)
+				)?.focus();
+			}
+
+			// Show or hide content
+			if (this.#method === 'invisible') {
+				this.style.visibility = shouldBeExpanded ? '' : 'hidden';
+			}
+
+			if (this.#method === 'hidden') {
+				this.toggleAttribute('hidden', !shouldBeExpanded);
+			}
+
+			// Enable or disable focusable items within the container
+			const fields = this.querySelectorAll('button, input, select, textarea');
+			for (const field of fields) {
+				field.toggleAttribute('disabled', !shouldBeExpanded);
+			}
+
+			// Emit custom event
+			emit(this, 'hide-until-selected', 'toggle', {
+				expanded: shouldBeExpanded,
+			});
+		}
+	},
+);

--- a/src/js/kelp.js
+++ b/src/js/kelp.js
@@ -13,4 +13,5 @@ import './components/toggle-pw.js';
 import './components/autogrow.js';
 import './components/subnav.js';
 import './components/select-all.js';
+import './components/hide-until-selected.js';
 import './components/invoker.polyfill.js';

--- a/tests/hide-until-selected/default.html
+++ b/tests/hide-until-selected/default.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="stylesheet" type="text/css" href="../../src/css/kelp.css">
+		<script type="module" src="../../src/js/kelp.js"></script>
+
+		<script>
+			// Ensures we can test the ready event
+			document.addEventListener('kelp-hide-until-selected:ready', (event) => {
+				console.log('ready');
+			});
+		</script>
+	</head>
+	<body>
+
+		<main class="container">
+
+			<h1>kelp-hide-until-selected - default settings</h1>
+
+			<kelp-hide-until-selected target="#pixar-movies [type='checkbox']" data-testid="content 1">
+				<div>
+					<p>I'm hidden unless a checkbox is checked.</p>
+				</div>
+			</kelp-hide-until-selected>
+
+			<kelp-hide-until-selected target="#pixar-movies [type='checkbox']" data-testid="content 2">
+				<div>
+					<p>I'm hidden, too.</p>
+				</div>
+			</kelp-hide-until-selected>
+
+			<fieldset>
+				<legend>What's your favorite Pixar movie?</legend>
+
+				<div id="pixar-movies">
+					<label for="up">
+						<input type="checkbox" id="up" name="movie" value="up">
+						Up!
+					</label>
+					<label for="wall-e">
+						<input type="checkbox" id="wall-e" name="movie" value="wall-e">
+						WALL-E
+					</label>
+					<label for="toy-story">
+						<input type="checkbox" id="toy-story" name="movie" value="toy-story">
+						Toy Story
+					</label>
+				</div>
+			</fieldset>
+
+		</main>
+
+	</body>
+</html>

--- a/tests/hide-until-selected/errors.html
+++ b/tests/hide-until-selected/errors.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="stylesheet" type="text/css" href="../../src/css/kelp.css">
+		<script type="module" src="../../src/js/kelp.js"></script>
+	</head>
+	<body>
+
+		<main class="container">
+
+			<h1>kelp-hide-until-selected - errors</h1>
+
+			<!-- no [target] -->
+			<kelp-hide-until-selected>
+				<div>
+					<p>I'm hidden unless a checkbox is checked.</p>
+				</div>
+			</kelp-hide-until-selected>
+
+		</main>
+
+	</body>
+</html>

--- a/tests/hide-until-selected/focus.html
+++ b/tests/hide-until-selected/focus.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="stylesheet" type="text/css" href="../../src/css/kelp.css">
+		<script type="module" src="../../src/js/kelp.js"></script>
+	</head>
+	<body>
+
+		<main class="container">
+
+			<h1>kelp-hide-until-selected - unchecked while focused within</h1>
+
+			<kelp-hide-until-selected target="#pixar-movies [type='checkbox']" focus="#up" events="test-event" data-testid="content">
+				<button data-testid="button">Press Me</button>
+			</kelp-hide-until-selected>
+
+			<fieldset>
+				<legend>What's your favorite Pixar movie?</legend>
+
+				<div id="pixar-movies">
+					<label for="up">
+						<input type="checkbox" id="up" name="movie" value="up">
+						Up!
+					</label>
+					<label for="wall-e">
+						<input type="checkbox" id="wall-e" name="movie" value="wall-e">
+						WALL-E
+					</label>
+					<label for="toy-story">
+						<input type="checkbox" id="toy-story" name="movie" value="toy-story">
+						Toy Story
+					</label>
+				</div>
+			</fieldset>
+
+		</main>
+
+		<script type="module">
+			const btn = document.querySelector('[data-testid="button"]');
+			const toyStory = document.querySelector('#toy-story');
+
+			btn.addEventListener('click', () => {
+				toyStory.checked = false;
+				const event = new CustomEvent('test-event', { bubbles: true });
+				document.dispatchEvent(event);
+			});
+		</script>
+
+	</body>
+</html>

--- a/tests/hide-until-selected/hide-until-selected.spec.js
+++ b/tests/hide-until-selected/hide-until-selected.spec.js
@@ -1,0 +1,171 @@
+import { expect, test } from '@playwright/test';
+
+// Component details
+const componentName = 'kelp-hide-until-selected';
+const testPath = '/tests/hide-until-selected';
+
+test.describe(`<${componentName}>`, () => {
+	test('component instantiates', async ({ page }) => {
+		let isReady = false;
+		page.on('console', (msg) => {
+			if (msg.text() !== 'ready') return;
+			isReady = true;
+		});
+		await page.goto(`${testPath}/default.html`);
+		expect(isReady).toEqual(true);
+		const component = page.locator(componentName).first();
+		await expect(component).toHaveAttribute('is-ready');
+	});
+
+	test('default component', async ({ page }) => {
+		await page.goto(`${testPath}/default.html`);
+
+		// Get elements
+		const targetEl1 = page.getByTestId('content 1');
+		const targetEl2 = page.getByTestId('content 2');
+		const upEl = page.locator('#up');
+		const walleEl = page.locator('#wall-e');
+
+		// Target content should be hidden by default
+		await expect(targetEl1).not.toBeVisible();
+		await expect(targetEl2).not.toBeVisible();
+
+		// Checking any checkbox should show the target content
+		await upEl.check();
+		await expect(targetEl1).toBeVisible();
+		await expect(targetEl2).toBeVisible();
+
+		// As long as at least one checkbox is checked, unchecking others should NOT hide the content
+		await walleEl.check();
+		await upEl.uncheck();
+		await expect(targetEl1).toBeVisible();
+		await expect(targetEl2).toBeVisible();
+
+		// Unchecking all checkboxes should hide the content
+		await walleEl.uncheck();
+		await expect(targetEl1).not.toBeVisible();
+		await expect(targetEl2).not.toBeVisible();
+	});
+
+	test('options and settings', async ({ page }) => {
+		await page.goto(`${testPath}/options.html`);
+
+		// Get elements
+		const targetEl1 = page.getByTestId('content 1');
+		const targetEl2 = page.getByTestId('content 2');
+		const targetEl3 = page.getByTestId('content 3');
+		const upEl = page.locator('#up');
+		const selectEl = page.getByTestId('select');
+		const checkboxEl = page.getByTestId('checkbox');
+		const inputEl = page.getByTestId('input');
+		const btnEl = page.getByTestId('btn');
+
+		// When at least one checkbox is checked, the content it controls should be visible by default
+		await expect(upEl).toBeChecked();
+		await expect(targetEl1).toBeVisible();
+		await expect(targetEl2).toBeVisible();
+		await expect(targetEl3).toBeVisible();
+
+		// Unchecking the checkbox should hide the target content unless it has [action="disabled"]
+		await upEl.uncheck();
+		await expect(targetEl1).not.toBeVisible();
+		await expect(targetEl2).not.toBeVisible();
+		await expect(targetEl3).toBeVisible();
+
+		// [action="disabled"] should disable inputs within the container
+		await expect(selectEl).toHaveAttribute('disabled');
+		await expect(checkboxEl).toHaveAttribute('disabled');
+		await expect(inputEl).toHaveAttribute('disabled');
+		await expect(btnEl).toHaveAttribute('disabled');
+
+		// The [invisible] attribute should hide the element but maintain its space in the DOM
+		const height = await targetEl2.evaluate((el) =>
+			Number.parseInt(window.getComputedStyle(el).height, 10),
+		);
+		const width = await targetEl2.evaluate((el) =>
+			Number.parseInt(window.getComputedStyle(el).width, 10),
+		);
+		expect(height).toBeGreaterThan(0);
+		expect(width).toBeGreaterThan(0);
+	});
+
+	test('unchecked while focused within', async ({ page }) => {
+		await page.goto(`${testPath}/focus.html`);
+
+		// Get elements
+		const targetEl = page.getByTestId('content');
+		const btnEl = page.getByTestId('button');
+		const upEl = page.locator('#up');
+		const toyStoryEl = page.locator('#toy-story');
+
+		// Show content and focus on button
+		await toyStoryEl.check();
+		await expect(targetEl).toBeVisible();
+		await btnEl.focus();
+
+		// Activate the button
+		// (this unchecks toyStoryEl and emits a custom event)
+		await btnEl.press('Enter');
+
+		// Content should be hidden.
+		// Focus should shift to the first checkbox.
+		await expect(upEl).toBeFocused();
+		await expect(targetEl).not.toBeVisible();
+	});
+
+	test('with <kelp-select-all>', async ({ page }) => {
+		await page.goto(`${testPath}/with-select-all.html`);
+
+		// Get elements
+		const targetEl1 = page.getByTestId('content 1');
+		const targetEl2 = page.getByTestId('content 2');
+		const targetEl3 = page.getByTestId('content 3');
+		const selectAllEl = page.locator('#select-all');
+		const selectEl = page.getByTestId('select');
+		const checkboxEl = page.getByTestId('checkbox');
+		const inputEl = page.getByTestId('input');
+		const btnEl = page.getByTestId('btn');
+
+		// Checking the select-all checkbox should show the target content
+		await selectAllEl.check();
+		await expect(targetEl1).toBeVisible();
+		await expect(targetEl2).toBeVisible();
+		await expect(targetEl3).toBeVisible();
+
+		// Unchecking the select-all checkbox should hide the target content unless it has [action="disabled"]
+		await selectAllEl.uncheck();
+		await expect(targetEl1).not.toBeVisible();
+		await expect(targetEl2).not.toBeVisible();
+		await expect(targetEl3).toBeVisible();
+
+		// Content in the [action="disabled"] target should be disabled
+		await expect(selectEl).toHaveAttribute('disabled');
+		await expect(checkboxEl).toHaveAttribute('disabled');
+		await expect(inputEl).toHaveAttribute('disabled');
+		await expect(btnEl).toHaveAttribute('disabled');
+	});
+
+	test('error handling', async ({ page }) => {
+		await page.goto(`${testPath}/errors.html`);
+
+		// Get elements
+		const wc = page.locator(componentName);
+
+		// No [is-ready] attribute
+		await expect(wc).not.toHaveAttribute('is-ready');
+	});
+
+	test('content should be visible if JS has not loaded', async ({ page }) => {
+		await page.goto(`${testPath}/no-js.html`);
+
+		// Get elements
+		const targetEl1 = page.getByTestId('content 1');
+		const targetEl2 = page.getByTestId('content 2');
+		const targetEl3 = page.getByTestId('content 3');
+
+		// The content is visible
+		await expect(targetEl1).toBeVisible();
+		await expect(targetEl2).toBeVisible();
+		await expect(targetEl3).toBeVisible();
+	});
+});

--- a/tests/hide-until-selected/no-js.html
+++ b/tests/hide-until-selected/no-js.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="stylesheet" type="text/css" href="../../src/css/kelp.css">
+	</head>
+	<body>
+
+		<main class="container">
+
+			<h1>kelp-hide-until-selected - no JS</h1>
+
+			<kelp-hide-until-selected target="#pixar-movies [type='checkbox']" data-testid="content 1">
+				<div>
+					<p>I'm hidden unless a checkbox is checked.</p>
+				</div>
+			</kelp-hide-until-selected>
+
+			<kelp-hide-until-selected target="#pixar-movies [type='checkbox']" action="invisible" data-testid="content 2">
+				<div>
+					<p>I'm hidden, too.</p>
+				</div>
+			</kelp-hide-until-selected>
+
+			<kelp-hide-until-selected target="#pixar-movies [type='checkbox']" action="disabled" data-testid="content 3">
+				<select data-testid="select">
+					<option></option>
+					<option>Merlin</option>
+					<option>Gandalf</option>
+					<option>Radagast</option>
+				</select>
+
+				<label>
+					<input type="checkbox" data-testid="checkbox">
+					Checkbox
+				</label>
+
+				<input type="text" data-testid="input">
+
+				<button data-testid="btn">Press Me</button>
+			</kelp-hide-until-selected>
+
+		</main>
+
+	</body>
+</html>

--- a/tests/hide-until-selected/options.html
+++ b/tests/hide-until-selected/options.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="stylesheet" type="text/css" href="../../src/css/kelp.css">
+		<script type="module" src="../../src/js/kelp.js"></script>
+	</head>
+	<body>
+
+		<main class="container">
+
+			<div class="stack">
+
+				<h1>kelp-hide-until-selected - options and settings</h1>
+
+				<kelp-hide-until-selected target="#pixar-movies [type='checkbox']" data-testid="content 1">
+					<div>
+						<p>I'm hidden unless a checkbox is checked.</p>
+					</div>
+				</kelp-hide-until-selected>
+
+				<kelp-hide-until-selected target="#pixar-movies [type='checkbox']" action="invisible" data-testid="content 2">
+					<div>
+						<p>I'm hidden, too.</p>
+					</div>
+				</kelp-hide-until-selected>
+
+				<kelp-hide-until-selected target="#pixar-movies [type='checkbox']" action="disabled" data-testid="content 3">
+					<select data-testid="select">
+						<option></option>
+						<option>Merlin</option>
+						<option>Gandalf</option>
+						<option>Radagast</option>
+					</select>
+
+					<label>
+						<input type="checkbox" data-testid="checkbox">
+						Checkbox
+					</label>
+
+					<input type="text" data-testid="input">
+
+					<button data-testid="btn">Press Me</button>
+				</kelp-hide-until-selected>
+
+				<fieldset>
+					<legend>What's your favorite Pixar movie?</legend>
+
+					<div id="pixar-movies">
+						<label for="up">
+							<input type="checkbox" id="up" name="movie" value="up" checked>
+							Up!
+						</label>
+						<label for="wall-e">
+							<input type="checkbox" id="wall-e" name="movie" value="wall-e">
+							WALL-E
+						</label>
+						<label for="toy-story">
+							<input type="checkbox" id="toy-story" name="movie" value="toy-story">
+							Toy Story
+						</label>
+					</div>
+				</fieldset>
+
+			</div>
+
+		</main>
+
+	</body>
+</html>

--- a/tests/hide-until-selected/with-select-all.html
+++ b/tests/hide-until-selected/with-select-all.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="stylesheet" type="text/css" href="../../src/css/kelp.css">
+		<script type="module" src="../../src/js/kelp.js"></script>
+	</head>
+	<body>
+
+		<main class="container">
+
+			<h1>kelp-hide-until-selected - with kelp-select-all</h1>
+
+			<kelp-hide-until-selected target="#pixar-movies [type='checkbox'], #select-all" data-testid="content 1">
+				<div>
+					<p>I'm hidden unless a checkbox is checked.</p>
+				</div>
+			</kelp-hide-until-selected>
+
+			<kelp-hide-until-selected target="#pixar-movies [type='checkbox'], #select-all" action="invisible" data-testid="content 2">
+				<div>
+					<p>I'm hidden, too.</p>
+				</div>
+			</kelp-hide-until-selected>
+
+			<kelp-hide-until-selected target="#pixar-movies [type='checkbox'], #select-all" action="disabled" data-testid="content 3">
+				<select data-testid="select">
+					<option></option>
+					<option>Merlin</option>
+					<option>Gandalf</option>
+					<option>Radagast</option>
+				</select>
+
+				<label>
+					<input type="checkbox" data-testid="checkbox">
+					Checkbox
+				</label>
+
+				<input type="text" data-testid="input">
+
+				<button data-testid="btn">Press Me</button>
+			</kelp-hide-until-selected>
+
+			<fieldset>
+				<legend>What's your favorite Pixar movie?</legend>
+
+				<kelp-select-all target="#pixar-movies [type='checkbox']">
+					<label for="select-all">
+						<input type="checkbox" id="select-all">
+						Select All
+					</label>
+				</kelp-select-all>
+
+				<div id="pixar-movies">
+					<label for="up">
+						<input type="checkbox" id="up" name="movie" value="up">
+						Up!
+					</label>
+					<label for="wall-e">
+						<input type="checkbox" id="wall-e" name="movie" value="wall-e">
+						WALL-E
+					</label>
+					<label for="toy-story">
+						<input type="checkbox" id="toy-story" name="movie" value="toy-story">
+						Toy Story
+					</label>
+				</div>
+			</fieldset>
+
+		</main>
+
+	</body>
+</html>


### PR DESCRIPTION
Partially implements https://github.com/cferdinandi/kelp/issues/46


## Description

This PR adds a `<kelp-hide-until-selected>` component, with options to hide, visually hide, and disable content until a controlling checkbox or radio button is selected.

A future update will add support for select menu options.